### PR TITLE
Use Goliath v0.9.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :gemcutter
 
-gem 'goliath', :git => 'git://github.com/postrank-labs/goliath.git'
+gem 'goliath', :git => 'git://github.com/postrank-labs/goliath.git', :tag => "v0.9.4"
 gem 'artii'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: git://github.com/postrank-labs/goliath.git
-  revision: 9c1e0383bc91c6088986a0f71e063b95f804aba2
+  revision: 557758aa1bc6c52cb9d5a77ad2ec1d55593d273f
+  tag: v0.9.4
   specs:
     goliath (0.9.4)
       async-rack
       em-synchrony (>= 1.0.0)
-      em-websocket
       eventmachine (>= 1.0.0.beta.3)
-      http_parser.rb (~> 0.5.3)
+      http_parser.rb
       http_router (~> 0.9.0)
       log4r
       multi_json
@@ -18,7 +18,6 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.2.6)
     artii (2.0.0)
       artii
     async-rack (0.5.1)
@@ -26,9 +25,6 @@ GEM
     diff-lcs (1.1.3)
     em-synchrony (1.0.1)
       eventmachine (>= 1.0.0.beta.1)
-    em-websocket (0.3.6)
-      addressable (>= 2.1.1)
-      eventmachine (>= 0.12.9)
     eventmachine (1.0.0.beta.4)
     foreman (0.41.0)
       thor (>= 0.13.6)
@@ -37,7 +33,7 @@ GEM
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
     log4r (1.1.10)
-    multi_json (1.0.4)
+    multi_json (1.3.4)
     rack (1.4.1)
     rack-accept-media-types (0.9)
     rack-contrib (1.1.0)


### PR DESCRIPTION
From 1.0 router will be removed. See https://groups.google.com/group/goliath-io/browse_thread/thread/499c65efc04d8543 for details
